### PR TITLE
Disable randomization of facewear when "randomize uniforms" is false

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -37,14 +37,15 @@ if (!isNil "_customLoadout") exitWith {
 		if !(_headgear in allArmoredHeadgear) then {
 			_unit addHeadgear (selectRandom (A3A_faction_reb get "headgear"));
 		};
+
+		if (goggles _unit != _goggles) then {
+			removeGoggles _unit;
+			_unit addGoggles _goggles;
+		};
 	} else {
 		_unit setUnitLoadout _customLoadout;
 	};
 
-    if (goggles _unit != _goggles) then {
-        removeGoggles _unit;
-        _unit addGoggles _goggles;
-    };
     _unit linkItem (selectRandom (A3A_faction_reb get "compasses"));
 	_unit linkItem (selectRandom (A3A_faction_reb get "maps"));
 	_unit linkItem (selectRandom (A3A_faction_reb get "watches"));


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    After submitting feature request #94 I realized I can probably do it myself. All that's been changed is the code that randomizes the goggles has been cut and pasted within the if-statement for `randomizeRebelLoadoutUniforms`.

### Please specify which Issue this PR Resolves.
closes #94

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Set a custom rebel uniform.
Spawn in the type of unit that was customized.
Do the above again with "randomize uniforms" toggled to the opposite state.

********************************************************
Notes:
~~Leaving this as a draft until I've completed the mandatory testing that I didn't check off above.~~ Done.